### PR TITLE
Use deep merge as the default attributes were removed with plain merge.

### DIFF
--- a/cookbooks/chef/recipes/dump_attributes.rb
+++ b/cookbooks/chef/recipes/dump_attributes.rb
@@ -43,6 +43,7 @@ if node['chef']['dump_attributes'] == 'true'
       attrs = JSON.parse("{}")
       
       # possible attribute methods: run_list, override_attrs, default_attrs, normal_attrs, automatic_attrs
+      attrs = attrs.deep_merge(node.automatic_attrs) unless node.automatic_attrs.empty?
       attrs = attrs.deep_merge(node.default_attrs) unless node.default_attrs.empty?
       attrs = attrs.deep_merge(node.normal_attrs) unless node.normal_attrs.empty?
       attrs = attrs.deep_merge(node.override_attrs) unless node.override_attrs.empty?

--- a/cookbooks/chef/recipes/dump_attributes.rb
+++ b/cookbooks/chef/recipes/dump_attributes.rb
@@ -17,6 +17,7 @@
 
 if node['chef']['dump_attributes'] == 'true'
   require 'pathname'
+  require 'active_support/core_ext/hash/deep_merge'
   
   d = directory Pathname(node['chef']['dump']['file']).dirname.to_s do
     action :nothing
@@ -42,15 +43,15 @@ if node['chef']['dump_attributes'] == 'true'
       attrs = JSON.parse("{}")
       
       # possible attribute methods: run_list, override_attrs, default_attrs, normal_attrs, automatic_attrs
-      attrs = attrs.merge(node.default_attrs) unless node.default_attrs.empty?
-      attrs = attrs.merge(node.normal_attrs) unless node.normal_attrs.empty?
-      attrs = attrs.merge(node.override_attrs) unless node.override_attrs.empty?
+      attrs = attrs.deep_merge(node.default_attrs) unless node.default_attrs.empty?
+      attrs = attrs.deep_merge(node.normal_attrs) unless node.normal_attrs.empty?
+      attrs = attrs.deep_merge(node.override_attrs) unless node.override_attrs.empty?
       
       # see also, https://github.com/opscode/chef-server-webui/pull/7
       recipe_json = "{ \"run_list\": \[ "
       recipe_json << node.run_list.expand(node.chef_environment).recipes.map! { |k| "\"#{k}\"" }.join(",")
       recipe_json << " \] }"
-      attrs = attrs.merge(JSON.parse(recipe_json))
+      attrs = attrs.deep_merge(JSON.parse(recipe_json))
       
       File.open(node['chef']['dump']['file'], 'w') { |file| file.write(JSON.pretty_generate(attrs)) }
     end


### PR DESCRIPTION
Adapted from http://jakshi.com/blog/2014/05/12/accessing-chef-attributes-in-serverspec-tests/
